### PR TITLE
Migrate from asciidoc to scdoc

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -1,6 +1,6 @@
 image: archlinux
 packages:
-    - asciidoc
+    - scdoc
 sources:
     - https://github.com/KnightOS/mkrom
 tasks:

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-build/
-CMakeCache.txt
-CMakeFiles
-cmake_install.cmake
-install_manifest.txt
 *.swp
 *.o
 bin/

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ bin/mkrom:main.o
 	mkdir -p bin/
 	$(CC) $(CFLAGS) $^ -o $@
 
-bin/mkrom.1:mkrom.1.txt
-	a2x --no-xmllint --doctype manpage --format manpage mkrom.1.txt -v -D bin/
+bin/mkrom.1:mkrom.1.scdoc
+	scdoc < mkrom.1.scdoc > bin/mkrom.1
 	
 DESTDIR=/usr/local
 BINDIR=$(DESTDIR)/bin/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Writes individual files into a ROM image
 
 ## Installation
 
-For Linux/Mac/etc, install make, asciidoc, and a C compiler, then:
+For Linux/Mac/etc, install make, scdoc, and a C compiler, then:
 
     $ make
     # make install # as root

--- a/mkrom.1.scdoc
+++ b/mkrom.1.scdoc
@@ -1,35 +1,28 @@
-/////
-vim:set ts=4 sw=4 tw=82 noet:
-/////
-mkrom (1)
-==========
+MKROM(1)
 
-Name
-----
+# NAME
+
 mkrom - Writes individual files into a ROM image
 
-Synopsis
---------
-'mkrom' _OUTPUT_ _LENGTH_ _FILES..._
+# SYNOPSIS
 
-Description
------------
+*mkrom* _OUTPUT_ _LENGTH_ _FILES..._
+
+# DESCRIPTION
 
 _FILES_ is a list of pairs consisting of the filename and an offset, separated
 by a colon. The offset marks the position of the input file in the _OUTPUT_
 file. _LENGTH_ determinds how large _OUTPUT_ shall be. It is filled with 0xFF
 octets before the input files are copied.
 
-Examples
---------
+# EXAMPLES
 
-mkrom example.rom 0x4000 temp1.bin:0x0 temp2.bin:0x200::
+*mkrom example.rom 0x4000 temp1.bin:0x0 temp2.bin:0x200*
 	Create a 16KiB large ROM image from two input files, placed at offsets 0 and
 	512.
 
-Authors
--------
+# AUTHORS
 
 Maintained by Drew DeVault <sir@cmpwn.com>, who is assisted by other open
 source contributors. For more information about mkrom development, see
-<https://github.com/KnightOS/mkrom>.
+https://github.com/KnightOS/mkrom.


### PR DESCRIPTION
Dumping asciidoc for the superior [scdoc](https://sr.ht/~sircmpwn/scdoc/).